### PR TITLE
Move classes for resque_ring binary out of Resque::Plugin namespace

### DIFF
--- a/lib/resque_ring/manager.rb
+++ b/lib/resque_ring/manager.rb
@@ -1,86 +1,82 @@
 require 'yaml'
 
-module Resque
-  module Plugins
-    module ResqueRing
-      class Manager
-        # @return [Hash{Symbol => String}] the options
-        #   used to create the Manager
-        attr_reader :options
+module ResqueRing
+  class Manager
+    # @return [Hash{Symbol => String}] the options
+    #   used to create the Manager
+    attr_reader :options
 
-        # @return [Integer] the time between script runs
-        attr_reader :delay
+    # @return [Integer] the time between script runs
+    attr_reader :delay
 
-        # @return [Hash{String => WorkerGroup}] list of {WorkerGroup}s
-        #   the manager manages, organized by name
-        attr_reader :worker_groups
+    # @return [Hash{String => WorkerGroup}] list of {WorkerGroup}s
+    #   the manager manages, organized by name
+    attr_reader :worker_groups
 
-        # @return [Registry] the backend store used for keeping
-        #   track of workers
-        attr_reader :registry
+    # @return [Registry] the backend store used for keeping
+    #   track of workers
+    attr_reader :registry
 
-        # @param options [Hash] options for the Manager, usually
-        #   including a key called config containing
-        #   the location of the config file.
-        # @return [Object] a new instance of Manager
-        def initialize(options = {})
-          @options = options
-          @worker_groups = {}
-          load_registry(options.delete(:redis))
+    # @param options [Hash] options for the Manager, usually
+    #   including a key called config containing
+    #   the location of the config file.
+    # @return [Object] a new instance of Manager
+    def initialize(options = {})
+      @options = options
+      @worker_groups = {}
+      load_registry(options.delete(:redis))
 
-          config = load_config_file(options[:config]) if options[:config]
-        end
+      config = load_config_file(options[:config]) if options[:config]
+    end
 
-        # Kicks off the manage cycle, sleeps, and then
-        # calls {Manager#run! itself} again
-        def run!
-          manage!
-          # sleep delay
-          # run!
-        end
+    # Kicks off the manage cycle, sleeps, and then
+    # calls {Manager#run! itself} again
+    def run!
+      manage!
+      # sleep delay
+      # run!
+    end
 
-        # Instructs each WorkerGroup to manage its own workers
-        # by calling {WorkerGroup#manage!}
-        def manage!
-          worker_groups.each_value { |wg| wg.manage! }
-        end
+    # Instructs each WorkerGroup to manage its own workers
+    # by calling {WorkerGroup#manage!}
+    def manage!
+      worker_groups.each_value { |wg| wg.manage! }
+    end
 
-        private
+    private
 
-        # Loads the contents of a YAML config file
-        # @param config [String] a string representing the location of
-        #   the config file
-        def load_config_file(config)
-          @config_file ||= Yambol.load_file(config)
-          if @config_file
-            set_delay(@config_file[:delay])
-            set_worker_groups(@config_file[:workers])
-          end
-        end
+    # Loads the contents of a YAML config file
+    # @param config [String] a string representing the location of
+    #   the config file
+    def load_config_file(config)
+      @config_file ||= Yambol.load_file(config)
+      if @config_file
+        set_delay(@config_file[:delay])
+        set_worker_groups(@config_file[:workers])
+      end
+    end
 
-        # Loads the registry with the proper options for redis
-        # @param redis_options [Hash] a hash containing the host
-        #   and port of the redis server
-        def load_registry(redis_options)
-          unless redis_options.is_a?(Hash) && redis_options.keys.include?(:host, :port)
-            redis_options = { host: 'localhost', port: 6379 }
-          end
-          @registry = RedisRegistry.new(redis_options)
-        end
+    # Loads the registry with the proper options for redis
+    # @param redis_options [Hash] a hash containing the host
+    #   and port of the redis server
+    def load_registry(redis_options)
+      unless redis_options.is_a?(Hash) && redis_options.keys.include?(:host, :port)
+        redis_options = { host: 'localhost', port: 6379 }
+      end
+      @registry = RedisRegistry.new(redis_options)
+    end
 
-        # Sets the time the script waits before calling #run! again
-        # @param delay [Integer] time to wait, in seconds
-        def set_delay(delay)
-          @delay = delay || 120
-        end
+    # Sets the time the script waits before calling #run! again
+    # @param delay [Integer] time to wait, in seconds
+    def set_delay(delay)
+      @delay = delay || 120
+    end
 
-        # Instantiates and collects new WorkerGroups based on config
-        # @param groups [Hash] a hash with names and options
-        def set_worker_groups(groups)
-          groups.each do |name, options|
-            @worker_groups[name] = WorkerGroup.new(name, options.merge(manager: self))
-          end
-        end
+    # Instantiates and collects new WorkerGroups based on config
+    # @param groups [Hash] a hash with names and options
+    def set_worker_groups(groups)
+      groups.each do |name, options|
+        @worker_groups[name] = WorkerGroup.new(name, options.merge(manager: self))
       end
     end
   end

--- a/lib/resque_ring/pool.rb
+++ b/lib/resque_ring/pool.rb
@@ -1,155 +1,149 @@
-module Resque
-  module Plugins
-    module ResqueRing
-      class Pool
-        extend HattrAccessor
+module ResqueRing
+  class Pool
+    extend HattrAccessor
 
-        # @return [WorkerGroup] {WorkerGroup} for this Pool
-        attr_reader :worker_group
+    # @return [WorkerGroup] {WorkerGroup} for this Pool
+    attr_reader :worker_group
 
-        # @return [Array] Array of Workers managed by this pool
-        attr_reader :workers
+    # @return [Array] Array of Workers managed by this pool
+    attr_reader :workers
 
-        # @!method first_at
-        #   @return [Integer] How many items should be in the queue before
-        #     spawning the first worker. Defaults to 1
-        hattr_reader :options, :first_at
+    # @!method first_at
+    #   @return [Integer] How many items should be in the queue before
+    #     spawning the first worker. Defaults to 1
+    hattr_reader :options, :first_at
 
-        # @!method global_max
-        #   @return [Integer] the maximum number of {Worker}s to run across
-        #     all servers. Ignored if set to 0. Defaults to 0
-        hattr_reader :options, :global_max
+    # @!method global_max
+    #   @return [Integer] the maximum number of {Worker}s to run across
+    #     all servers. Ignored if set to 0. Defaults to 0
+    hattr_reader :options, :global_max
 
-        # @!method max
-        #   @return [Integer] the maximum number of {Worker}s to run locally.
-        #     Defaults to 5.
-        hattr_reader :options, :max
+    # @!method max
+    #   @return [Integer] the maximum number of {Worker}s to run locally.
+    #     Defaults to 5.
+    hattr_reader :options, :max
 
-        # @!method min
-        #   @return [Integer] the minimum number of Workers to keep alive locally.
-        #     Defaults to 1
-        hattr_reader :options, :min
+    # @!method min
+    #   @return [Integer] the minimum number of Workers to keep alive locally.
+    #     Defaults to 1
+    hattr_reader :options, :min
 
-        # @param options [Hash] options for this Pool
-        def initialize(options)
-          @workers = []
-          @worker_group = options.delete(:worker_group)
-          @options = defaults.merge(options)
-        end
+    # @param options [Hash] options for this Pool
+    def initialize(options)
+      @workers = []
+      @worker_group = options.delete(:worker_group)
+      @options = defaults.merge(options)
+    end
 
-        # Spins workers up or down as required
-        def manage!
-          despawn_if_necessary
-          spawn_if_necessary
-        end
+    # Spins workers up or down as required
+    def manage!
+      despawn_if_necessary
+      spawn_if_necessary
+    end
 
-        # Removes a worker from the {Registry}
-        # associated with {#worker_group}
-        # @param worker [Worker] the worker to be removed
-        def deregister(worker)
-          worker_group.registry.deregister(worker_group.name, worker.pid)
-        end
+    # Removes a worker from the {Registry}
+    # associated with {#worker_group}
+    # @param worker [Worker] the worker to be removed
+    def deregister(worker)
+      worker_group.registry.deregister(worker_group.name, worker.pid)
+    end
 
-        # Adds a worker to the list of {#workers} and
-        # then adds it to the {Registry}
-        # associated with {#worker_group}
-        # @param worker [Worker] the worker to be added
-        def register(worker)
-          @workers << worker
-          options = worker_group.manager.delay ? { delay: worker_group.wait_time } : {}
-          worker_group.registry.register(worker_group.name, worker.pid, options)
-        end
+    # Adds a worker to the list of {#workers} and
+    # then adds it to the {Registry}
+    # associated with {#worker_group}
+    # @param worker [Worker] the worker to be added
+    def register(worker)
+      @workers << worker
+      options = worker_group.manager.delay ? { delay: worker_group.wait_time } : {}
+      worker_group.registry.register(worker_group.name, worker.pid, options)
+    end
 
-        # @return [Integer] number of current workers for this Pool
-        #   fetched from the {Registry}
-        def current_workers
-          worker_group.registry.current(worker_group.name, :worker_count).to_i
-        end
+    # @return [Integer] number of current workers for this Pool
+    #   fetched from the {Registry}
+    def current_workers
+      worker_group.registry.current(worker_group.name, :worker_count).to_i
+    end
 
-        # @return [Array] pids of the current worker processes as
-        #   fetched from the {Registry}
-        def worker_processes
-          worker_group.registry.list(worker_group.name, :worker_list) || []
-        end
+    # @return [Array] pids of the current worker processes as
+    #   fetched from the {Registry}
+    def worker_processes
+      worker_group.registry.list(worker_group.name, :worker_list) || []
+    end
 
-        # @return [String] a string containing the time the last
-        #   {Worker} was spawned
-        def last_spawned
-          worker_group.registry.current(worker_group.name, :last_spawned)
-        end
+    # @return [String] a string containing the time the last
+    #   {Worker} was spawned
+    def last_spawned
+      worker_group.registry.current(worker_group.name, :last_spawned)
+    end
 
-        # @return [Boolean] true if a key called
-        #   'spawn_blocked' returns a value of 1
-        #   (meaning it hasn't expired in Redis)
-        def spawn_blocked?
-          worker_group.registry.current(worker_group.name, :spawn_blocked) == '1'
-        end
+    # @return [Boolean] true if a key called
+    #   'spawn_blocked' returns a value of 1
+    #   (meaning it hasn't expired in Redis)
+    def spawn_blocked?
+      worker_group.registry.current(worker_group.name, :spawn_blocked) == '1'
+    end
 
-        # @return [Boolean] true if {#spawn_blocked?}
-        #   returns false
-        def able_to_spawn?
-          !spawn_blocked?
-        end
+    # @return [Boolean] true if {#spawn_blocked?}
+    #   returns false
+    def able_to_spawn?
+      !spawn_blocked?
+    end
 
-        # @return [Boolean] true if {#worker_processes} spawned
-        #   is greater than {#min}
-        def min_workers_spawned?
-          worker_processes.size >= min
-        end
+    # @return [Boolean] true if {#worker_processes} spawned
+    #   is greater than {#min}
+    def min_workers_spawned?
+      worker_processes.size >= min
+    end
 
-        # @return [Boolean] true if {#worker_processes} spawned
-        #    is less than {#max}
-        def room_for_more?
-          under_local_max? && under_global_max?
-        end
+    # @return [Boolean] true if {#worker_processes} spawned
+    #    is less than {#max}
+    def room_for_more?
+      under_local_max? && under_global_max?
+    end
 
-        private
+    private
 
-        def under_local_max?
-          workers.size < max
-        end
+    def under_local_max?
+      workers.size < max
+    end
 
-        def under_global_max?
-          return true if global_max == 0
-          worker_processes.size < global_max
-        end
+    def under_global_max?
+      return true if global_max == 0
+      worker_processes.size < global_max
+    end
 
-        def defaults
-          {
-            first_at:    1,
-            global_max:  0,
-            max:         5,
-            min:         1
-          }
-        end
+    def defaults
+      {
+        first_at:    1,
+        global_max:  0,
+        max:         5,
+        min:         1
+      }
+    end
 
-        def despawn_if_necessary
-          despawn! if worker_group.wants_to_remove_workers?
-        end
+    def despawn_if_necessary
+      despawn! if worker_group.wants_to_remove_workers?
+    end
 
-        def despawn!
-          worker_to_fire = @workers.pop
-          worker_to_fire.stop!
-          deregister(worker_to_fire)
-        end
+    def despawn!
+      worker_to_fire = @workers.pop
+      worker_to_fire.stop!
+      deregister(worker_to_fire)
+    end
 
-        def spawn_if_necessary
-          spawn! and return unless min_workers_spawned?
-          spawn! if worker_group.wants_to_add_workers? && room_for_more?
-        end
+    def spawn_if_necessary
+      spawn! and return unless min_workers_spawned?
+      spawn! if worker_group.wants_to_add_workers? && room_for_more?
+    end
 
-        def spawn!
-          worker = Resque::Plugins::ResqueRing::Worker.new(worker_options)
-          worker.start!
-          register(worker) if worker.alive?
-        end
+    def spawn!
+      worker = ResqueRing::Worker.new(worker_options)
+      worker.start!
+      register(worker) if worker.alive?
+    end
 
-        def worker_options
-          worker_group.worker_options.merge({ pool: self })
-        end
-      end
+    def worker_options
+      worker_group.worker_options.merge({ pool: self })
     end
   end
 end
-
-

--- a/lib/resque_ring/queue.rb
+++ b/lib/resque_ring/queue.rb
@@ -1,39 +1,35 @@
-module Resque
-  module Plugins
-    module ResqueRing
-      class Queue
-        # @return [String] the name of this Queue in Resque
-        attr_reader :name
+module ResqueRing
+  class Queue
+    # @return [String] the name of this Queue in Resque
+    attr_reader :name
 
-        # @!method to_s
-        # @return [String] the name of the queue
-        alias :to_s :name
+    # @!method to_s
+    # @return [String] the name of the queue
+    alias :to_s :name
 
-        # @return [WorkerGroup] the {WorkerGroup} that owns this Queue
-        attr_reader :worker_group
+    # @return [WorkerGroup] the {WorkerGroup} that owns this Queue
+    attr_reader :worker_group
 
-        # @return [Resque] an instance of {Resque}
-        attr_reader :store
+    # @return [Resque] an instance of {Resque}
+    attr_reader :store
 
-        # @param options [Hash] the options, including name,
-        #  parent {WorkerGroup} and {Resque} instance
-        #  for this queue
-        def initialize(options = {})
-          @name = options.delete(:name)
-          @worker_group = options.delete(:worker_group)
-          @store = options.delete(:store)
-        end
+    # @param options [Hash] the options, including name,
+    #  parent {WorkerGroup} and {Resque} instance
+    #  for this queue
+    def initialize(options = {})
+      @name = options.delete(:name)
+      @worker_group = options.delete(:worker_group)
+      @store = options.delete(:store)
+    end
 
-        # @return [Integer] the size of this queue in Resque
-        def size
-          store.size(name) rescue 0
-        end
+    # @return [Integer] the size of this queue in Resque
+    def size
+      store.size(name) rescue 0
+    end
 
-        # @return [String] a simple representation of the instance
-        def inspect
-          "Queue:#{object_id}:#{name}:#{size}"
-        end
-      end
+    # @return [String] a simple representation of the instance
+    def inspect
+      "Queue:#{object_id}:#{name}:#{size}"
     end
   end
 end

--- a/lib/resque_ring/redis_registry.rb
+++ b/lib/resque_ring/redis_registry.rb
@@ -1,85 +1,81 @@
-module Resque
-  module Plugins
-    module ResqueRing
-      class RedisRegistry
-        include Registry
+module ResqueRing
+  class RedisRegistry
+    include Registry
 
-        PREFIX = 'ResqueRing'
+    PREFIX = 'ResqueRing'
 
-        extend Forwardable
-        def_delegators :@redis, :get, :set, :sadd, :srem, :incr, :decr
+    extend Forwardable
+    def_delegators :@redis, :get, :set, :sadd, :srem, :incr, :decr
 
-        # @param redis_options [Hash] a hash of options for the redis instance
-        # @option redis_options [String] :host the server where redis is running
-        # @option redis_options [Integer, String] :port the port redis is running on
-        def initialize(redis_options)
-          @redis = Redis.new(redis_options)
-        end
+    # @param redis_options [Hash] a hash of options for the redis instance
+    # @option redis_options [String] :host the server where redis is running
+    # @option redis_options [Integer, String] :port the port redis is running on
+    def initialize(redis_options)
+      @redis = Redis.new(redis_options)
+    end
 
-        # Deletes all our keys associated with namespace from Redis.
-        # Useful in tests and when starting fresh.
-        # @param namespace [String] usually {WorkerGroup#name}
-        def reset!(namespace)
-          @redis.keys(_key(namespace, '*')).each { |k| @redis.del(k) }
-        end
+    # Deletes all our keys associated with namespace from Redis.
+    # Useful in tests and when starting fresh.
+    # @param namespace [String] usually {WorkerGroup#name}
+    def reset!(namespace)
+      @redis.keys(_key(namespace, '*')).each { |k| @redis.del(k) }
+    end
 
-        # Registers a new {Worker} instance into Redis by storing its
-        # PID, incrementing the total count of workers, recording the
-        # time of spawn and setting a key to block spawning until expired.
-        # @param name     [String] usually {WorkerGroup#name}
-        # @param pid      [Integer] the PID of the {Worker} process
-        # @param options  [Hash] a hash containing additional options
-        # @option options [Integer] :delay How long spawning is blocked.
-        #   this information comes from {WorkerGroup#wait_time}
-        def register(name, pid, options = {})
-          atomically do |multi|
-            multi.sadd  _key(name, 'worker_list'), localize(pid)
-            multi.incr  _key(name, 'worker_count')
-            multi.set   _key(name, 'last_spawned'), Time.now.utc
-            multi.setex _key(name, 'spawn_blocked'), options.fetch(:delay, 120), 1
-          end
-        end
-
-        # De-registers a {Worker} instance identified by pid from Redis by
-        # decrementing worker_count and removing the worker from the list
-        # of workers
-        # @param name [String]  usually {WorkerGroup#name}
-        # @param pid  [Integer] the the PID of the {Worker} process
-        def deregister(name, pid)
-          atomically do |multi|
-            multi.decr  _key(name, 'worker_count')
-            multi.srem  _key(name, 'worker_list'), localize(pid)
-          end
-        end
-
-        # Gets the members of a Redis Set
-        # @param name   [String]  usually {WorkerGroup#name}
-        # @param focus  [String]  the redis key for the Set
-        # @return [Array] the members of the Set
-        def list(name, focus)
-          @redis.smembers _key(name, focus)
-        end
-
-        # Gets the contents of a simple Redis key
-        # @param name   [String]  usually {WorkerGroup#name}
-        # @param focus  [String]  the redis key
-        # @return       [String]  the contents of the key
-        def current(name, focus)
-          get _key(name, focus)
-        end
-
-        # Perform operations within block in a Redis transaction
-        # @yieldparam multi [Redis::Multi] a Redis.multi context (for atomic operations)
-        def atomically(&block)
-          @redis.multi { |multi| yield multi }
-        end
-
-        private
-
-        def _key(namespace, key)
-          [PREFIX, namespace, key].join(':')
-        end
+    # Registers a new {Worker} instance into Redis by storing its
+    # PID, incrementing the total count of workers, recording the
+    # time of spawn and setting a key to block spawning until expired.
+    # @param name     [String] usually {WorkerGroup#name}
+    # @param pid      [Integer] the PID of the {Worker} process
+    # @param options  [Hash] a hash containing additional options
+    # @option options [Integer] :delay How long spawning is blocked.
+    #   this information comes from {WorkerGroup#wait_time}
+    def register(name, pid, options = {})
+      atomically do |multi|
+        multi.sadd  _key(name, 'worker_list'), localize(pid)
+        multi.incr  _key(name, 'worker_count')
+        multi.set   _key(name, 'last_spawned'), Time.now.utc
+        multi.setex _key(name, 'spawn_blocked'), options.fetch(:delay, 120), 1
       end
+    end
+
+    # De-registers a {Worker} instance identified by pid from Redis by
+    # decrementing worker_count and removing the worker from the list
+    # of workers
+    # @param name [String]  usually {WorkerGroup#name}
+    # @param pid  [Integer] the the PID of the {Worker} process
+    def deregister(name, pid)
+      atomically do |multi|
+        multi.decr  _key(name, 'worker_count')
+        multi.srem  _key(name, 'worker_list'), localize(pid)
+      end
+    end
+
+    # Gets the members of a Redis Set
+    # @param name   [String]  usually {WorkerGroup#name}
+    # @param focus  [String]  the redis key for the Set
+    # @return [Array] the members of the Set
+    def list(name, focus)
+      @redis.smembers _key(name, focus)
+    end
+
+    # Gets the contents of a simple Redis key
+    # @param name   [String]  usually {WorkerGroup#name}
+    # @param focus  [String]  the redis key
+    # @return       [String]  the contents of the key
+    def current(name, focus)
+      get _key(name, focus)
+    end
+
+    # Perform operations within block in a Redis transaction
+    # @yieldparam multi [Redis::Multi] a Redis.multi context (for atomic operations)
+    def atomically(&block)
+      @redis.multi { |multi| yield multi }
+    end
+
+    private
+
+    def _key(namespace, key)
+      [PREFIX, namespace, key].join(':')
     end
   end
 end

--- a/lib/resque_ring/registry.rb
+++ b/lib/resque_ring/registry.rb
@@ -1,20 +1,16 @@
-module Resque
-  module Plugins
-    module ResqueRing
-      module Registry
-        HOST = `hostname`.strip.freeze
+module ResqueRing
+  module Registry
+    HOST = `hostname`.strip.freeze
 
-        # @return [String] the local machine's hostname
-        def host; HOST; end
+    # @return [String] the local machine's hostname
+    def host; HOST; end
 
-        # Adds the host to the given value to namespace it
-        # by server
-        # @param value [String,Integer] the value to be localized
-        # @return [String] the given value, with {#host} prepended
-        def localize(value)
-          "#{host}:#{value}"
-        end
-      end
+    # Adds the host to the given value to namespace it
+    # by server
+    # @param value [String,Integer] the value to be localized
+    # @return [String] the given value, with {#host} prepended
+    def localize(value)
+      "#{host}:#{value}"
     end
   end
 end

--- a/lib/resque_ring/worker.rb
+++ b/lib/resque_ring/worker.rb
@@ -1,72 +1,68 @@
 require 'childprocess'
 
 # A managed worker process.
-module Resque
-  module Plugins
-    module ResqueRing
-      class Worker
-        extend Forwardable
-        def_delegators :process, :pid, :alive?, :exited?
+module ResqueRing
+  class Worker
+    extend Forwardable
+    def_delegators :process, :pid, :alive?, :exited?
 
-        # @return [Pool] {Pool} that owns this Worker
-        attr_reader :pool
+    # @return [Pool] {Pool} that owns this Worker
+    attr_reader :pool
 
-        # @return [Hash] options used to create this Worker instance
-        attr_reader :options
+    # @return [Hash] options used to create this Worker instance
+    attr_reader :options
 
-        # @return [#build] the process manager for this Worker
-        attr_reader :process
+    # @return [#build] the process manager for this Worker
+    attr_reader :process
 
-        # @param options [Hash] the options for creating this Worker
-        # @option options [#build] :process_mgr a ChildProcess-compatible
-        #   class to manage the Worker process
-        # @option options [Pool] :pool {Pool} that owns this Worker
-        # @option options [Array] :spawner an Array of elements used to
-        #   build the spawn command (from {WorkerGroup#spawner})
-        # @option options [Hash] :env from {WorkerGroup#environment}
-        # @option options [String] :cwd from {WorkerGroup#work_dir}
-        def initialize(options)
-          @process_mgr = options.delete(:process_mgr) || ChildProcess
-          @pool = options.delete(:pool)
-          @options = options
+    # @param options [Hash] the options for creating this Worker
+    # @option options [#build] :process_mgr a ChildProcess-compatible
+    #   class to manage the Worker process
+    # @option options [Pool] :pool {Pool} that owns this Worker
+    # @option options [Array] :spawner an Array of elements used to
+    #   build the spawn command (from {WorkerGroup#spawner})
+    # @option options [Hash] :env from {WorkerGroup#environment}
+    # @option options [String] :cwd from {WorkerGroup#work_dir}
+    def initialize(options)
+      @process_mgr = options.delete(:process_mgr) || ChildProcess
+      @pool = options.delete(:pool)
+      @options = options
 
-          build!
-        end
+      build!
+    end
 
-        # Instructs a worker to start its process
-        def start!
-          process.start
-        end
+    # Instructs a worker to start its process
+    def start!
+      process.start
+    end
 
-        # Instructs a worker to die
-        def stop!
-          process.stop
-        end
+    # Instructs a worker to die
+    def stop!
+      process.stop
+    end
 
-        private
+    private
 
-        def build!
-          @process = @process_mgr.build(*options[:spawner])
+    def build!
+      @process = @process_mgr.build(*options[:spawner])
 
-          set_working_dir(options[:cwd])
-          set_environment(options[:env])
-        end
+      set_working_dir(options[:cwd])
+      set_environment(options[:env])
+    end
 
-        def reset_env!
-          ENV.keys.each { |key| process.environment[key] = nil }
-        end
+    def reset_env!
+      ENV.keys.each { |key| process.environment[key] = nil }
+    end
 
-        def set_environment(env)
-          return unless env && env.size > 0
+    def set_environment(env)
+      return unless env && env.size > 0
 
-          reset_env!
-          env.each { |k,v| process.environment[k.upcase] = v } unless env.empty?
-        end
+      reset_env!
+      env.each { |k,v| process.environment[k.upcase] = v } unless env.empty?
+    end
 
-        def set_working_dir(cwd)
-          process.cwd = cwd if cwd
-        end
-      end
+    def set_working_dir(cwd)
+      process.cwd = cwd if cwd
     end
   end
 end

--- a/lib/resque_ring/worker_group.rb
+++ b/lib/resque_ring/worker_group.rb
@@ -1,146 +1,142 @@
-module Resque
-  module Plugins
-    module ResqueRing
-      class WorkerGroup
-        extend HattrAccessor
+module ResqueRing
+  class WorkerGroup
+    extend HattrAccessor
 
-        # @return [String] name of the WorkerGroup
-        attr_reader :name
+    # @return [String] name of the WorkerGroup
+    attr_reader :name
 
-        # @return [Manager] {Manager} class for this WorkerGroup
-        attr_reader :manager
+    # @return [Manager] {Manager} class for this WorkerGroup
+    attr_reader :manager
 
-        # @return [Hash{String => Queue}] a hash containing
-        #   the {Queue} instances managed by this
-        #   WorkerGroup, organized by name
-        attr_reader :queues
+    # @return [Hash{String => Queue}] a hash containing
+    #   the {Queue} instances managed by this
+    #   WorkerGroup, organized by name
+    attr_reader :queues
 
-        # @!method spawn_rate
-        #   @return [Object] How many new workers to spawn at a time.
-        #     Defaults to 1
-        hattr_reader :options, :spawn_rate
+    # @!method spawn_rate
+    #   @return [Object] How many new workers to spawn at a time.
+    #     Defaults to 1
+    hattr_reader :options, :spawn_rate
 
-        # @!method threshold
-        #   @return [Object] the number of queue items
-        #     needed before spawning more workers. Defaults to 100
-        hattr_reader :options, :threshold
+    # @!method threshold
+    #   @return [Object] the number of queue items
+    #     needed before spawning more workers. Defaults to 100
+    hattr_reader :options, :threshold
 
-        # @!method wait_time
-        #   @return [Object] How long to wait after spawning before
-        #     spawning a new worker. Should be longer than the global
-        #     delay. Defaults to 60
-        hattr_reader :options, :wait_time
+    # @!method wait_time
+    #   @return [Object] How long to wait after spawning before
+    #     spawning a new worker. Should be longer than the global
+    #     delay. Defaults to 60
+    hattr_reader :options, :wait_time
 
-        # @!method remove_when_idle
-        #   @return [Boolean] whether or not to reduce
-        #     worker capacity when idle. Defaults to false
-        hattr_reader :options, :remove_when_idle
+    # @!method remove_when_idle
+    #   @return [Boolean] whether or not to reduce
+    #     worker capacity when idle. Defaults to false
+    hattr_reader :options, :remove_when_idle
 
-        # @param name [String] a name for this WorkerGroup
-        # @param options [Hash] options for this WorkerGroup
-        def initialize(name, options = {})
-          @name = name.to_s
-          @manager = options.delete(:manager)
+    # @param name [String] a name for this WorkerGroup
+    # @param options [Hash] options for this WorkerGroup
+    def initialize(name, options = {})
+      @name = name.to_s
+      @manager = options.delete(:manager)
 
-          build_queues(options.fetch(:queues, []))
-          @options = defaults.merge(options)
-        end
+      build_queues(options.fetch(:queues, []))
+      @options = defaults.merge(options)
+    end
 
-        # A list of environment variables used when
-        # spawning a {Worker Worker}
-        # @return [Hash] ENV variable names & values
-        def environment
-          @env ||= @options[:spawner][:env]
-        end
+    # A list of environment variables used when
+    # spawning a {Worker Worker}
+    # @return [Hash] ENV variable names & values
+    def environment
+      @env ||= @options[:spawner][:env]
+    end
 
-        # Instructs a {Pool} to manage its workers
-        def manage!
-          pool.manage!
-        end
+    # Instructs a {Pool} to manage its workers
+    def manage!
+      pool.manage!
+    end
 
-        # @return [Pool] the pool of workers for this WorkerGroup
-        def pool
-          @pool ||= Resque::Plugins::ResqueRing::Pool.new(@options[:pool].merge(worker_group: self))
-        end
+    # @return [Pool] the pool of workers for this WorkerGroup
+    def pool
+      @pool ||= ResqueRing::Pool.new(@options[:pool].merge(worker_group: self))
+    end
 
-        # @return [Boolean] true if all associated queues are empty
-        def queues_are_empty?
-          queues_total == 0
-        end
+    # @return [Boolean] true if all associated queues are empty
+    def queues_are_empty?
+      queues_total == 0
+    end
 
-        # @return [Integer] sum of sizes of all associated queues
-        def queues_total
-          queues.values.map(&:size).reduce(:+)
-        end
+    # @return [Integer] sum of sizes of all associated queues
+    def queues_total
+      queues.values.map(&:size).reduce(:+)
+    end
 
-        # @return [Registry] the {Registry} associated with this
-        #   WorkerGroup's {Manager}
-        def registry
-          manager.registry
-        end
+    # @return [Registry] the {Registry} associated with this
+    #   WorkerGroup's {Manager}
+    def registry
+      manager.registry
+    end
 
-        # @return [Array] an array of strings for building the
-        #   spawning command
-        def spawn_command
-          @spawn_command ||= @options[:spawner][:command]
-        end
+    # @return [Array] an array of strings for building the
+    #   spawning command
+    def spawn_command
+      @spawn_command ||= @options[:spawner][:command]
+    end
 
-        # collects an [Array] of spawn command elements
-        # while replacing a placeholder with a list
-        # of associated {Queue Queues} concatenated into
-        # a String
-        # @return [Array] an array of strings used by
-        #   the {Pool} when spawning a {Worker}
-        def spawner
-          spawn_command.collect { |c| c.gsub('{{queues}}', "QUEUES=#{queues.map(&:to_s).join(',')}") }
-        end
+    # collects an [Array] of spawn command elements
+    # while replacing a placeholder with a list
+    # of associated {Queue Queues} concatenated into
+    # a String
+    # @return [Array] an array of strings used by
+    #   the {Pool} when spawning a {Worker}
+    def spawner
+      spawn_command.collect { |c| c.gsub('{{queues}}', "QUEUES=#{queues.map(&:to_s).join(',')}") }
+    end
 
-        # @return [Boolean] true if total items in all queues
-        #   is greater than {#threshold} and the {Pool} is
-        #   ready to spawn a new worker
-        def wants_to_add_workers?
-          queues_total >= threshold && pool.able_to_spawn?
-        end
+    # @return [Boolean] true if total items in all queues
+    #   is greater than {#threshold} and the {Pool} is
+    #   ready to spawn a new worker
+    def wants_to_add_workers?
+      queues_total >= threshold && pool.able_to_spawn?
+    end
 
-        # @return [Boolean] true if all queues are empty
-        #   and {#remove_when_idle} returns true
-        def wants_to_remove_workers?
-          remove_when_idle && queues_are_empty?
-        end
+    # @return [Boolean] true if all queues are empty
+    #   and {#remove_when_idle} returns true
+    def wants_to_remove_workers?
+      remove_when_idle && queues_are_empty?
+    end
 
-        # @return [String] the working directory for
-        #   the spawner command
-        def work_dir
-          @work_dir ||= @options[:spawner][:dir]
-        end
+    # @return [String] the working directory for
+    #   the spawner command
+    def work_dir
+      @work_dir ||= @options[:spawner][:dir]
+    end
 
-        # @return [Hash] options for the {Worker} that
-        #   {Pool} will spin up on request
-        def worker_options
-          { spawner: spawner, env: environment, cwd: work_dir }
-        end
+    # @return [Hash] options for the {Worker} that
+    #   {Pool} will spin up on request
+    def worker_options
+      { spawner: spawner, env: environment, cwd: work_dir }
+    end
 
-        private
+    private
 
-        def build_queues(queues)
-          @queues ||= {}
+    def build_queues(queues)
+      @queues ||= {}
 
-          return if queues.nil?
-          queues.each do |q|
-            @queues.store(q, Queue.new(name: q, worker_group: self))
-          end
-        end
-
-        def defaults
-          {
-            spawn_rate:       1,
-            threshold:        100,
-            wait_time:        60,
-            remove_when_idle: false,
-            pool:             {}
-          }
-        end
+      return if queues.nil?
+      queues.each do |q|
+        @queues.store(q, Queue.new(name: q, worker_group: self))
       end
+    end
+
+    def defaults
+      {
+        spawn_rate:       1,
+        threshold:        100,
+        wait_time:        60,
+        remove_when_idle: false,
+        pool:             {}
+      }
     end
   end
 end

--- a/spec/resque_ring/manager_base_spec.rb
+++ b/spec/resque_ring/manager_base_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Resque::Plugins::ResqueRing::Manager do
+describe ResqueRing::Manager do
   context 'a new instance' do
     context 'with no options specified' do
-      subject { Resque::Plugins::ResqueRing::Manager.new }
+      subject { ResqueRing::Manager.new }
 
       it 'responds to #run!' do
         subject.must_respond_to(:run!)
@@ -14,14 +14,14 @@ describe Resque::Plugins::ResqueRing::Manager do
       end
 
       it 'has a registry' do
-        subject.registry.must_be_kind_of(Resque::Plugins::ResqueRing::Registry)
+        subject.registry.must_be_kind_of(ResqueRing::Registry)
       end
     end
 
     context 'with config file given' do
       let(:config) { './spec/support/config_with_delay.yml' }
-      let(:mgr) { Resque::Plugins::ResqueRing::Manager.new(config: config) }
-      subject { Resque::Plugins::ResqueRing::Manager.new(config: config) }
+      let(:mgr) { ResqueRing::Manager.new(config: config) }
+      subject { ResqueRing::Manager.new(config: config) }
 
       it 'sets the delay option specified' do
         subject.delay.must_equal(60)
@@ -43,7 +43,7 @@ describe Resque::Plugins::ResqueRing::Manager do
           subject { mgr.worker_groups[:indexing] }
 
           it 'is a WorkerGroup' do
-            subject.must_be_instance_of Resque::Plugins::ResqueRing::WorkerGroup
+            subject.must_be_instance_of ResqueRing::WorkerGroup
           end
 
           it 'is named with its key' do

--- a/spec/resque_ring/pool_base_spec.rb
+++ b/spec/resque_ring/pool_base_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Resque::Plugins::ResqueRing::Pool do
-  let(:manager) { Resque::Plugins::ResqueRing::Manager.new }
-  let(:worker_group) { Resque::Plugins::ResqueRing::WorkerGroup.new('test', manager: manager) }
+describe ResqueRing::Pool do
+  let(:manager) { ResqueRing::Manager.new }
+  let(:worker_group) { ResqueRing::WorkerGroup.new('test', manager: manager) }
   let(:options) { Hash.new.merge(worker_group: worker_group) }
-  let(:pool) { Resque::Plugins::ResqueRing::Pool.new(options) }
+  let(:pool) { ResqueRing::Pool.new(options) }
 
   subject { pool }
 
@@ -13,7 +13,7 @@ describe Resque::Plugins::ResqueRing::Pool do
   end
 
   context 'through the registry' do
-    let(:worker) { Resque::Plugins::ResqueRing::Worker.new(pool: pool) }
+    let(:worker) { ResqueRing::Worker.new(pool: pool) }
     let(:fake_pid) { 1001 }
     let(:localized_pid) { "#{manager.registry.host}:1001" }
 
@@ -79,7 +79,7 @@ describe Resque::Plugins::ResqueRing::Pool do
     context 'when worker_group wants to remove workers' do
       before do
         worker_group.stubs(:wants_to_remove_workers?).returns(true)
-        3.times { pool.workers.unshift(Resque::Plugins::ResqueRing::Worker.new(pool: pool)) }
+        3.times { pool.workers.unshift(ResqueRing::Worker.new(pool: pool)) }
 
         @worker_to_fire = pool.workers.last
         @worker_to_fire.process.expects(:stop).returns(true)
@@ -104,10 +104,10 @@ describe Resque::Plugins::ResqueRing::Pool do
         pool.expects(:min_workers_spawned?).returns(false)
         worker_group.expects(:worker_options).returns({})
 
-        @worker = Resque::Plugins::ResqueRing::Worker.new(pool: pool)
+        @worker = ResqueRing::Worker.new(pool: pool)
 
         # creates a new worker
-        Resque::Plugins::ResqueRing::Worker.expects(:new).at_least_once.returns(@worker)
+        ResqueRing::Worker.expects(:new).at_least_once.returns(@worker)
 
         # attempts to start
         @worker.expects(:start).at_least_once.returns(true)
@@ -129,7 +129,7 @@ describe Resque::Plugins::ResqueRing::Pool do
       end
 
       after do
-        Resque::Plugins::ResqueRing::Worker.unstub
+        ResqueRing::Worker.unstub
         @worker.unstub
         pool.unstub
       end
@@ -146,10 +146,10 @@ describe Resque::Plugins::ResqueRing::Pool do
             pool.expects(:room_for_more?).returns(true)
             worker_group.expects(:worker_options).returns({})
 
-            @worker = Resque::Plugins::ResqueRing::Worker.new(pool: pool)
+            @worker = ResqueRing::Worker.new(pool: pool)
 
             # creates a new worker
-            Resque::Plugins::ResqueRing::Worker.expects(:new).at_least_once.returns(@worker)
+            ResqueRing::Worker.expects(:new).at_least_once.returns(@worker)
 
             # attempts to start
             @worker.expects(:start).at_least_once.returns(true)
@@ -171,7 +171,7 @@ describe Resque::Plugins::ResqueRing::Pool do
           end
 
           after do
-            Resque::Plugins::ResqueRing::Worker.unstub
+            ResqueRing::Worker.unstub
             @worker.unstub
             pool.unstub
           end
@@ -273,10 +273,10 @@ describe Resque::Plugins::ResqueRing::Pool do
 
   describe '#spawn!' do
     before do
-      @worker = Resque::Plugins::ResqueRing::Worker.new(pool: pool)
+      @worker = ResqueRing::Worker.new(pool: pool)
 
       pool.worker_group.expects(:worker_options).at_least_once.returns({})
-      Resque::Plugins::ResqueRing::Worker.expects(:new).with(pool: pool).returns(@worker)
+      ResqueRing::Worker.expects(:new).with(pool: pool).returns(@worker)
       pool.expects(:register).with(@worker).returns(true)
       @worker.expects(:alive?).returns(true)
     end
@@ -289,7 +289,7 @@ describe Resque::Plugins::ResqueRing::Pool do
 
     after do
       pool.worker_group.unstub(:worker_options)
-      Resque::Plugins::ResqueRing::Worker.unstub(:new)
+      ResqueRing::Worker.unstub(:new)
       pool.unstub(:register)
       @worker.unstub(:alive?)
     end
@@ -320,7 +320,7 @@ describe Resque::Plugins::ResqueRing::Pool do
       max:         4,
       first_at:    10
     } }
-    subject { Resque::Plugins::ResqueRing::Pool.new(options) }
+    subject { ResqueRing::Pool.new(options) }
 
     it 'sets proper global_max' do
       subject.global_max.must_equal options[:global_max]

--- a/spec/resque_ring/queue_base_spec.rb
+++ b/spec/resque_ring/queue_base_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 require './spec/support/hash_queue_store'
 
-describe Resque::Plugins::ResqueRing::Queue do
-  let(:mgr) { Resque::Plugins::ResqueRing::Manager.new({}) }
+describe ResqueRing::Queue do
+  let(:mgr) { ResqueRing::Manager.new({}) }
   let(:options) { Hash.new.merge(manager: mgr) }
-  let(:wg) { Resque::Plugins::ResqueRing::WorkerGroup.new('indexing', options) }
+  let(:wg) { ResqueRing::WorkerGroup.new('indexing', options) }
   let(:store) { HashQueueStore.new }
-  subject { Resque::Plugins::ResqueRing::Queue.new(name: 'test', worker_group: wg, store: store) }
+  subject { ResqueRing::Queue.new(name: 'test', worker_group: wg, store: store) }
 
   it 'knows its name' do
     subject.name.must_equal('test')

--- a/spec/resque_ring/redis_registry_base_spec.rb
+++ b/spec/resque_ring/redis_registry_base_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 require 'resque_ring/redis_registry'
 
-describe Resque::Plugins::ResqueRing::RedisRegistry do
+describe ResqueRing::RedisRegistry do
   let(:mock_redis)  { MOCK_REDIS }
-  let(:registry)    { Resque::Plugins::ResqueRing::RedisRegistry.new({}) }
-  let(:prefix)      { "#{Resque::Plugins::ResqueRing::RedisRegistry::PREFIX}:test" }
+  let(:registry)    { ResqueRing::RedisRegistry.new({}) }
+  let(:prefix)      { "#{ResqueRing::RedisRegistry::PREFIX}:test" }
 
   before { registry.reset!('test') }
 

--- a/spec/resque_ring/worker_base_spec.rb
+++ b/spec/resque_ring/worker_base_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe Resque::Plugins::ResqueRing::Worker do
+describe ResqueRing::Worker do
   context 'a new worker' do
     context 'initialized with a pool' do
-      let(:pool) { Resque::Plugins::ResqueRing::Pool.new({}) }
-      let(:worker) { Resque::Plugins::ResqueRing::Worker.new(pool: pool) }
+      let(:pool) { ResqueRing::Pool.new({}) }
+      let(:worker) { ResqueRing::Worker.new(pool: pool) }
 
       subject { worker }
 
@@ -14,7 +14,7 @@ describe Resque::Plugins::ResqueRing::Worker do
 
       context 'with a spawner given' do
         let(:args) { ['ruby', '-e', 'sleep'] }
-        let(:worker) { Resque::Plugins::ResqueRing::Worker.new(pool: pool, spawner: args, env: { rails_env: 'test' }) }
+        let(:worker) { ResqueRing::Worker.new(pool: pool, spawner: args, env: { rails_env: 'test' }) }
         let(:process) { ChildProcess.new }
 
         before do

--- a/spec/resque_ring/worker_group_base_spec.rb
+++ b/spec/resque_ring/worker_group_base_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 require './spec/support/hash_queue_store'
 
-describe Resque::Plugins::ResqueRing::WorkerGroup do
-  let(:mgr) { Resque::Plugins::ResqueRing::Manager.new({}) }
+describe ResqueRing::WorkerGroup do
+  let(:mgr) { ResqueRing::Manager.new({}) }
   let(:options) { Hash.new.merge(manager: mgr) }
-  subject { Resque::Plugins::ResqueRing::WorkerGroup.new('indexing', options) }
+  subject { ResqueRing::WorkerGroup.new('indexing', options) }
 
   it 'stores a reference to its manager' do
     subject.manager.must_equal mgr
@@ -12,9 +12,9 @@ describe Resque::Plugins::ResqueRing::WorkerGroup do
 
   context 'queues' do
     let(:store) { HashQueueStore.new }
-    let(:wg) { Resque::Plugins::ResqueRing::WorkerGroup.new('indexing', options) }
-    let(:queue_a) { Resque::Plugins::ResqueRing::Queue.new(name: 'queue_a', worker_group: wg, store: store) }
-    let(:queue_b) { Resque::Plugins::ResqueRing::Queue.new(name: 'queue_b', worker_group: wg, store: store) }
+    let(:wg) { ResqueRing::WorkerGroup.new('indexing', options) }
+    let(:queue_a) { ResqueRing::Queue.new(name: 'queue_a', worker_group: wg, store: store) }
+    let(:queue_b) { ResqueRing::Queue.new(name: 'queue_b', worker_group: wg, store: store) }
 
     before do
       store.queues['queue_a'] = 1
@@ -52,13 +52,13 @@ describe Resque::Plugins::ResqueRing::WorkerGroup do
     end
 
     it 'creates a Pool' do
-      subject.pool.class.must_equal Resque::Plugins::ResqueRing::Pool
+      subject.pool.class.must_equal ResqueRing::Pool
     end
   end
 
   context 'with a provided configuration' do
     let(:options) { file = Yambol.load_file('./spec/support/config_with_delay.yml')[:workers][:indexing] }
-    let(:wg) { Resque::Plugins::ResqueRing::WorkerGroup.new('indexing', options.merge(manager: mgr)) }
+    let(:wg) { ResqueRing::WorkerGroup.new('indexing', options.merge(manager: mgr)) }
     subject { wg }
 
     it 'knows its spawn command' do
@@ -94,7 +94,7 @@ describe Resque::Plugins::ResqueRing::WorkerGroup do
     end
 
     it 'creates a Pool' do
-      subject.pool.must_be_instance_of Resque::Plugins::ResqueRing::Pool
+      subject.pool.must_be_instance_of ResqueRing::Pool
     end
 
     context 'when #manage! is called' do


### PR DESCRIPTION
This will allow for better encapsulation when I write actual
Resque::Plugin code

(Also, moved resque_ring specs into spec/resque_ring)
